### PR TITLE
feat: filter by unlabeled features

### DIFF
--- a/src/webview/components/Toolbar.tsx
+++ b/src/webview/components/Toolbar.tsx
@@ -103,11 +103,16 @@ export function Toolbar({ onOpenSettings }: { onOpenSettings: () => void }) {
         className={selectClassName}
       >
         <option value="all">All Labels</option>
-        {labels.map((l) => (
-          <option key={l} value={l}>
-            {l}
-          </option>
-        ))}
+        <option value="unlabeled">Unlabeled</option>
+        {labels.length > 0 && (
+          <optgroup label="Labels">
+            {labels.map((l) => (
+              <option key={l} value={`label:${l}`}>
+                {l}
+              </option>
+            ))}
+          </optgroup>
+        )}
       </select>
       )}
 

--- a/src/webview/store/index.ts
+++ b/src/webview/store/index.ts
@@ -182,7 +182,11 @@ export const useStore = create<KanbanState>((set, get) => ({
         }
 
         // Label filter
-        if (labelFilter !== 'all' && !f.labels.includes(labelFilter)) return false
+        if (labelFilter === 'unlabeled') {
+          if (f.labels.length > 0) return false
+        } else if (labelFilter.startsWith('label:')) {
+          if (!f.labels.includes(labelFilter.slice(6))) return false
+        }
 
         // Due date filter
         if (dueDateFilter !== 'all') {


### PR DESCRIPTION
Implements #35

<img width="483" height="322" alt="image" src="https://github.com/user-attachments/assets/d930042a-7135-46a9-95ad-daa4acde0223" />

And it works if the user has labels actually named `all`/`unlabeled`:

<img width="520" height="388" alt="image" src="https://github.com/user-attachments/assets/f00d137f-ffc0-4560-afa1-b58c7acda300" />

<img width="388" height="270" alt="image" src="https://github.com/user-attachments/assets/c4babe1d-118f-4e15-ac86-d0f00c2cb664" />

<img width="398" height="288" alt="image" src="https://github.com/user-attachments/assets/9317985e-6ca4-4ff2-a5f9-1f71bb4d166e" />
