### PR TITLE
feat: add ability to rename labels

### DIFF
--- a/src/extension/KanbanPanel.ts
+++ b/src/extension/KanbanPanel.ts
@@ -163,6 +163,9 @@ export class KanbanPanel {
           case 'moveAllCards':
             await this._moveAllCards(message.sourceColumnId, message.targetColumnId)
             break
+          case 'renameLabel':
+            await this._renameLabel(message.oldName, message.newName)
+            break
           case 'startWithAI':
             await this._startWithAI(message.agent, message.permissionMode)
             break
@@ -905,6 +908,36 @@ export class KanbanPanel {
     })
     terminal.show()
     terminal.sendText(command)
+  }
+
+  private async _renameLabel(oldName: string, newName: string): Promise<void> {
+    if (!oldName || !newName || oldName === newName) return
+
+    const trimmedNew = newName.trim()
+    if (!trimmedNew) return
+
+    let updatedCount = 0
+    for (const feature of this._features) {
+      const idx = feature.labels.indexOf(oldName)
+      if (idx === -1) continue
+
+      // Replace old label with new, avoiding duplicates
+      if (feature.labels.includes(trimmedNew)) {
+        // New name already exists on this feature — just remove the old one
+        feature.labels.splice(idx, 1)
+      } else {
+        feature.labels[idx] = trimmedNew
+      }
+      feature.modified = new Date().toISOString()
+
+      const content = this._serializeFeature(feature)
+      await vscode.workspace.fs.writeFile(vscode.Uri.file(feature.filePath), new TextEncoder().encode(content))
+      updatedCount++
+    }
+
+    if (updatedCount > 0) {
+      this._sendFeaturesToWebview()
+    }
   }
 
   private async _promptFilenamePatternMigration(): Promise<void> {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -116,3 +116,4 @@ export type WebviewMessage =
   | { type: 'openSettings' }
   | { type: 'toggleColumnCollapsed'; columnId: string }
   | { type: 'moveAllCards'; sourceColumnId: string; targetColumnId: string }
+  | { type: 'renameLabel'; oldName: string; newName: string }

--- a/src/webview/components/LabelManager.tsx
+++ b/src/webview/components/LabelManager.tsx
@@ -1,0 +1,199 @@
+import { useState, useRef, useEffect } from 'react'
+import { X, Pencil, Check, Tag } from 'lucide-react'
+import { useStore } from '../store'
+import { vscode } from '../vscodeApi'
+
+interface LabelManagerProps {
+  onClose: () => void
+}
+
+export function LabelManager({ onClose }: Readonly<LabelManagerProps>) {
+  const { getUniqueLabels, features, labelFilter, setLabelFilter } = useStore()
+  const labels = getUniqueLabels()
+
+  const [editingLabel, setEditingLabel] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Focus input when editing starts
+  useEffect(() => {
+    if (editingLabel && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [editingLabel])
+
+  // Close on click outside
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    // Delay to avoid the opening click from closing immediately
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClick)
+    }, 0)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('mousedown', handleClick)
+    }
+  }, [onClose])
+
+  // Close on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (editingLabel) {
+          setEditingLabel(null)
+        } else {
+          onClose()
+        }
+      }
+    }
+    globalThis.addEventListener('keydown', handleKeyDown)
+    return () => globalThis.removeEventListener('keydown', handleKeyDown)
+  }, [editingLabel, onClose])
+
+  const getLabelCount = (label: string): number => {
+    return features.filter(f => f.labels.includes(label)).length
+  }
+
+  const handleStartEdit = (label: string) => {
+    setEditingLabel(label)
+    setEditValue(label)
+  }
+
+  const handleConfirmRename = () => {
+    if (editingLabel && editValue.trim() && editValue.trim() !== editingLabel) {
+      const newName = editValue.trim()
+      vscode.postMessage({ type: 'renameLabel', oldName: editingLabel, newName })
+      // If the filter was set to the old label, update it
+      if (labelFilter === editingLabel) {
+        setLabelFilter(newName)
+      }
+    }
+    setEditingLabel(null)
+  }
+
+  const handleCancelEdit = () => {
+    setEditingLabel(null)
+  }
+
+  if (labels.length === 0) {
+    onClose()
+    return null
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div className="fixed inset-0 z-40" />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        className="absolute top-full right-0 mt-1 z-50 rounded-lg shadow-lg min-w-[260px] max-w-[340px] bg-white dark:bg-zinc-800"
+        style={{
+          border: '1px solid var(--vscode-dropdown-border, var(--vscode-panel-border))',
+        }}
+      >
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-3 py-2"
+          style={{ borderBottom: '1px solid var(--vscode-panel-border)' }}
+        >
+          <div className="flex items-center gap-1.5">
+            <Tag size={14} style={{ color: 'var(--vscode-descriptionForeground)' }} />
+            <span className="text-sm font-medium" style={{ color: 'var(--vscode-foreground)' }}>
+              Manage Labels
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-0.5 rounded transition-colors"
+            style={{ color: 'var(--vscode-descriptionForeground)' }}
+            onMouseEnter={e => e.currentTarget.style.color = 'var(--vscode-foreground)'}
+            onMouseLeave={e => e.currentTarget.style.color = 'var(--vscode-descriptionForeground)'}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Label list */}
+        <div className="py-1 max-h-[300px] overflow-y-auto">
+          {labels.map((label) => (
+            <div
+              key={label}
+              className="flex items-center gap-2 px-3 py-1.5 group"
+            >
+              {editingLabel === label ? (
+                <div className="flex items-center gap-1 flex-1 min-w-0">
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    value={editValue}
+                    onChange={(e) => setEditValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleConfirmRename()
+                      if (e.key === 'Escape') handleCancelEdit()
+                    }}
+                    className="flex-1 min-w-0 text-sm rounded px-1.5 py-0.5 focus:outline-none"
+                    style={{
+                      background: 'var(--vscode-input-background)',
+                      color: 'var(--vscode-input-foreground)',
+                      border: '1px solid var(--vscode-focusBorder)',
+                    }}
+                  />
+                  <button
+                    onClick={handleConfirmRename}
+                    className="p-1 rounded transition-colors shrink-0"
+                    title="Confirm rename"
+                    style={{ color: 'var(--vscode-testing-iconPassed, #22c55e)' }}
+                  >
+                    <Check size={14} />
+                  </button>
+                  <button
+                    onClick={handleCancelEdit}
+                    className="p-1 rounded transition-colors shrink-0"
+                    title="Cancel"
+                    style={{ color: 'var(--vscode-descriptionForeground)' }}
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <span
+                    className="flex-1 min-w-0 text-sm truncate"
+                    style={{ color: 'var(--vscode-foreground)' }}
+                  >
+                    {label}
+                  </span>
+                  <span
+                    className="text-xs shrink-0"
+                    style={{ color: 'var(--vscode-descriptionForeground)' }}
+                    title={`Used on ${getLabelCount(label)} card${getLabelCount(label) === 1 ? '' : 's'}`}
+                  >
+                    {getLabelCount(label)}
+                  </span>
+                  <button
+                    onClick={() => handleStartEdit(label)}
+                    className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                    title="Rename label"
+                    style={{ color: 'var(--vscode-descriptionForeground)' }}
+                    onMouseEnter={e => e.currentTarget.style.color = 'var(--vscode-foreground)'}
+                    onMouseLeave={e => e.currentTarget.style.color = 'var(--vscode-descriptionForeground)'}
+                  >
+                    <Pencil size={12} />
+                  </button>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/webview/components/Toolbar.tsx
+++ b/src/webview/components/Toolbar.tsx
@@ -1,6 +1,8 @@
-import { Search, X, Columns, Rows, Settings } from 'lucide-react'
+import { Search, X, Columns, Rows, Settings, Tags } from 'lucide-react'
 import { useStore, type DueDateFilter } from '../store'
 import type { Priority } from '../../shared/types'
+import { useState } from 'react'
+import { LabelManager } from './LabelManager'
 
 const priorities: { value: Priority | 'all'; label: string }[] = [
   { value: 'all', label: 'All Priorities' },
@@ -45,6 +47,8 @@ export function Toolbar({ onOpenSettings }: { onOpenSettings: () => void }) {
   const assignees = getUniqueAssignees()
   const labels = getUniqueLabels()
   const filtersActive = hasActiveFilters()
+
+  const [labelManagerOpen, setLabelManagerOpen] = useState(false)
 
   return (
     <div className="flex items-center gap-2 px-4 py-2 border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/50 flex-wrap">
@@ -146,6 +150,23 @@ export function Toolbar({ onOpenSettings }: { onOpenSettings: () => void }) {
       >
         {layout === 'horizontal' ? <Rows size={16} /> : <Columns size={16} />}
       </button>
+
+
+      {/* Manage Labels */}
+      {cardSettings.showLabels && labels.length > 0 && (
+        <div className="relative">
+          <button
+            onClick={() => setLabelManagerOpen(!labelManagerOpen)}
+            className="flex items-center gap-1 px-2 py-1.5 text-sm text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-md transition-colors"
+            title="Manage labels"
+          >
+            <Tags size={14} />
+          </button>
+          {labelManagerOpen && (
+            <LabelManager onClose={() => setLabelManagerOpen(false)} />
+          )}
+        </div>
+      )}
 
       {/* Settings */}
       <button


### PR DESCRIPTION
Implements #39.

Notes:

- Renaming label X to label Y when label Y already exists automatically merges the labels.
- Input string is auto-trimmed (i.e, ` foo ` becomes `foo`)
- Trying to rename to an empty string (or with white spaces only) aborts the operation

https://github.com/user-attachments/assets/83571bcb-2c61-4896-807a-4cc09111eb12

