### PR TITLE
feat: add assignee autocomplete from existing tickets

### DIFF
--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -34,6 +34,10 @@ function App(): React.JSX.Element {
     frontmatter: FeatureFrontmatter
     contentVersion: number
   } | null>(null)
+  const editingFeatureRef = useRef(editingFeature)
+  useEffect(() => {
+    editingFeatureRef.current = editingFeature
+  }, [editingFeature])
 
   // Undo delete stack
   const [pendingDeletes, setPendingDeletes] = useState<{ id: string; feature: Feature }[]>([])
@@ -199,7 +203,7 @@ function App(): React.JSX.Element {
           setColumns(message.columns)
           setCollapsedColumns(message.collapsedColumns ?? [])
           if (message.settings) {
-            if (message.settings.markdownEditorMode && editingFeature) {
+            if (message.settings.markdownEditorMode && editingFeatureRef.current) {
               setEditingFeature(null)
             }
             setCardSettings(message.settings)

--- a/src/webview/components/AssigneeInput.tsx
+++ b/src/webview/components/AssigneeInput.tsx
@@ -1,0 +1,109 @@
+import { useState, useRef, useMemo } from 'react'
+import { useStore } from '../store'
+import { t } from '../lib/i18n'
+
+/** Assignee field with suggestions from assignees on other tickets (derived from store `features`). */
+export function AssigneeInput({ value, onChange }: { value: string; onChange: (value: string) => void }) {
+  const [isFocused, setIsFocused] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const features = useStore(s => s.features)
+
+  const existingAssignees = useMemo(() => {
+    const assignees = new Set<string>()
+    features.forEach(f => {
+      if (f.assignee) assignees.add(f.assignee)
+    })
+    return Array.from(assignees).sort()
+  }, [features])
+
+  const suggestions = useMemo(() => {
+    if (!value.trim()) return existingAssignees
+    return existingAssignees.filter(
+      a => a.toLowerCase().includes(value.toLowerCase()) && a !== value
+    )
+  }, [value, existingAssignees])
+
+  const showSuggestions = isFocused && suggestions.length > 0
+
+  const initials = value.trim()
+    ? value
+        .trim()
+        .split(/\s+/)
+        .map(w => w[0])
+        .join('')
+        .toUpperCase()
+        .slice(0, 2)
+    : null
+
+  return (
+    <div className="relative flex-1 min-w-0">
+      <div
+        className="flex items-center gap-2 cursor-text"
+        onClick={() => inputRef.current?.focus()}
+      >
+        {initials && (
+          <span
+            className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold"
+            style={{
+              background: 'var(--vscode-badge-background)',
+              color: 'var(--vscode-badge-foreground)',
+            }}
+          >
+            {initials}
+          </span>
+        )}
+        <input
+          ref={inputRef}
+          type="text"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setTimeout(() => setIsFocused(false), 150)}
+          placeholder={t('editor.noAssignee')}
+          className="flex-1 min-w-0 bg-transparent border-none outline-none text-xs"
+          style={{ color: value ? 'var(--vscode-foreground)' : 'var(--vscode-descriptionForeground)' }}
+        />
+      </div>
+      {showSuggestions && (
+        <div
+          className="absolute top-full left-0 mt-1 z-20 rounded-lg shadow-lg py-1 max-h-[160px] overflow-auto min-w-[180px]"
+          style={{
+            background: 'var(--vscode-dropdown-background)',
+            border: '1px solid var(--vscode-dropdown-border, var(--vscode-panel-border))',
+          }}
+        >
+          {suggestions.map(assignee => (
+            <button
+              key={assignee}
+              type="button"
+              onMouseDown={e => {
+                e.preventDefault()
+                onChange(assignee)
+              }}
+              className="w-full flex items-center gap-2 px-3 py-1.5 text-xs transition-colors"
+              style={{ color: 'var(--vscode-dropdown-foreground)' }}
+              onMouseEnter={e => (e.currentTarget.style.background = 'var(--vscode-list-hoverBackground)')}
+              onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+            >
+              <span
+                className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold"
+                style={{
+                  background: 'var(--vscode-badge-background)',
+                  color: 'var(--vscode-badge-foreground)',
+                }}
+              >
+                {assignee
+                  .split(/\s+/)
+                  .map(w => w[0])
+                  .join('')
+                  .toUpperCase()
+                  .slice(0, 2)}
+              </span>
+              <span>{assignee}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/webview/components/CreateFeatureDialog.tsx
+++ b/src/webview/components/CreateFeatureDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
+import { AssigneeInput } from './AssigneeInput'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
@@ -108,90 +109,6 @@ function Dropdown({ value, options, onChange, className }: DropdownProps) {
             ))}
           </div>
         </>
-      )}
-    </div>
-  )
-}
-
-function AssigneeInput({ value, onChange }: { value: string; onChange: (value: string) => void }) {
-  const [isFocused, setIsFocused] = useState(false)
-  const inputRef = useRef<HTMLInputElement>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const features = useStore(s => s.features)
-
-  const existingAssignees = useMemo(() => {
-    const assignees = new Set<string>()
-    features.forEach(f => { if (f.assignee) assignees.add(f.assignee) })
-    return Array.from(assignees).sort()
-  }, [features])
-
-  const suggestions = useMemo(() => {
-    if (!value.trim()) return existingAssignees
-    return existingAssignees.filter(a => a.toLowerCase().includes(value.toLowerCase()) && a !== value)
-  }, [value, existingAssignees])
-
-  const showSuggestions = isFocused && suggestions.length > 0
-
-  const initials = value.trim()
-    ? value.trim().split(/\s+/).map(w => w[0]).join('').toUpperCase().slice(0, 2)
-    : null
-
-  return (
-    <div ref={containerRef} className="relative flex-1">
-      <div
-        className="flex items-center gap-2 cursor-text"
-        onClick={() => inputRef.current?.focus()}
-      >
-        {initials && (
-          <span
-            className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold"
-            style={{
-              background: 'var(--vscode-badge-background)',
-              color: 'var(--vscode-badge-foreground)',
-            }}
-          >{initials}</span>
-        )}
-        <input
-          ref={inputRef}
-          type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setTimeout(() => setIsFocused(false), 150)}
-          placeholder={t('editor.noAssignee')}
-          className="flex-1 bg-transparent border-none outline-none text-xs"
-          style={{ color: value ? 'var(--vscode-foreground)' : 'var(--vscode-descriptionForeground)' }}
-        />
-      </div>
-      {showSuggestions && (
-        <div
-          className="absolute top-full left-0 mt-1 z-20 rounded-lg shadow-lg py-1 max-h-[160px] overflow-auto min-w-[180px]"
-          style={{
-            background: 'var(--vscode-dropdown-background)',
-            border: '1px solid var(--vscode-dropdown-border, var(--vscode-panel-border))',
-          }}
-        >
-          {suggestions.map(assignee => (
-            <button
-              key={assignee}
-              type="button"
-              onMouseDown={(e) => { e.preventDefault(); onChange(assignee) }}
-              className="w-full flex items-center gap-2 px-3 py-1.5 text-xs transition-colors"
-              style={{ color: 'var(--vscode-dropdown-foreground)' }}
-              onMouseEnter={e => e.currentTarget.style.background = 'var(--vscode-list-hoverBackground)'}
-              onMouseLeave={e => e.currentTarget.style.background = 'transparent'}
-            >
-              <span
-                className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold"
-                style={{
-                  background: 'var(--vscode-badge-background)',
-                  color: 'var(--vscode-badge-foreground)',
-                }}
-              >{assignee.split(/\s+/).map(w => w[0]).join('').toUpperCase().slice(0, 2)}</span>
-              <span>{assignee}</span>
-            </button>
-          ))}
-        </div>
       )}
     </div>
   )

--- a/src/webview/components/FeatureEditor.tsx
+++ b/src/webview/components/FeatureEditor.tsx
@@ -8,6 +8,7 @@ import type { FeatureFrontmatter, Priority, FeatureStatus, AIAgent, AIPermission
 import { cn } from '../lib/utils'
 import { t } from '../lib/i18n'
 import { useStore } from '../store'
+import { AssigneeInput } from './AssigneeInput'
 
 interface MarkdownStorage {
   markdown: { getMarkdown: () => string }
@@ -578,25 +579,10 @@ export function FeatureEditor({ featureId, content, frontmatter, contentVersion,
         )}
         {cardSettings.showAssignee && (
           <PropertyRow label={t('property.assignee')} icon={<User size={13} />}>
-            <div className="flex items-center gap-2">
-              {currentFrontmatter.assignee && (
-                <span
-                  className="shrink-0 w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold"
-                  style={{
-                    background: 'var(--vscode-badge-background)',
-                    color: 'var(--vscode-badge-foreground)',
-                  }}
-                >{currentFrontmatter.assignee.split(/\s+/).filter(Boolean).map(w => w[0]).join('').toUpperCase().slice(0, 2)}</span>
-              )}
-              <input
-                type="text"
-                value={currentFrontmatter.assignee || ''}
-                onChange={(e) => handleFrontmatterUpdate({ assignee: e.target.value || null })}
-                placeholder={t('editor.noAssignee')}
-                className="bg-transparent border-none outline-none text-xs w-32"
-                style={{ color: currentFrontmatter.assignee ? 'var(--vscode-foreground)' : 'var(--vscode-descriptionForeground)' }}
-              />
-            </div>
+            <AssigneeInput
+              value={currentFrontmatter.assignee || ''}
+              onChange={(v) => handleFrontmatterUpdate({ assignee: v || null })}
+            />
           </PropertyRow>
         )}
         {cardSettings.showDueDate && (


### PR DESCRIPTION
When typing an assignee on a ticket or in the create-ticket flow, the UI now suggests names already used on other tickets, consistent with how label suggestions work.

Implementation:

- Added a shared `AssigneeInput` component that derives a sorted unique list of assignees from the webview store’s `features` (recomputed when the board changes—no separate cache).
- Wired it into `FeatureEditor` (previously a plain text field) and refactored `CreateFeatureDialog` to use the same component.

**Testing**

- `npm run lint`, `npm run typecheck`, and `npm run build` (per CONTRIBUTING).
- Manual check in the Extension Development Host: open a ticket and “Create ticket”, focus assignee, confirm suggestions match other cards and filter while typing.

<img width="720" height="374" alt="image" src="https://github.com/user-attachments/assets/3c76ad18-6cc3-410d-a526-3650d99c27c2" />

```
% npm run lint

> kanban-markdown@1.12.1 lint
> eslint src
```

```
% npm run typecheck

> kanban-markdown@1.12.1 typecheck
> tsc --noEmit
```

```
% npm run build

> kanban-markdown@1.12.1 build
> npm run build:extension && npm run build:webview


> kanban-markdown@1.12.1 build:extension
> esbuild src/extension/index.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node


  dist/extension.js  69.3kb

⚡ Done in 5ms

> kanban-markdown@1.12.1 build:webview
> vite build

The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
vite v5.4.21 building for production...
✓ 1861 modules transformed.
../../dist/webview/style.css                  46.42 kB │ gzip:   7.81 kB
../../dist/webview/icons-yv5o5LQP.js          16.62 kB │ gzip:   5.05 kB │ map:    41.19 kB
../../dist/webview/react-vendor-DhOiG4Vm.js  134.01 kB │ gzip:  43.19 kB │ map:   328.41 kB
../../dist/webview/index.js                  578.49 kB │ gzip: 196.63 kB │ map: 2,499.97 kB

(!) Some chunks are larger than 300 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 1.67s
```