### PR TITLE
fix(codex): replace deprecated --approval-mode with --ask-for-approval (#47)

### DIFF
--- a/src/extension/FeatureHeaderProvider.ts
+++ b/src/extension/FeatureHeaderProvider.ts
@@ -130,13 +130,13 @@ export class FeatureHeaderProvider implements vscode.WebviewViewProvider {
             }
             case 'codex': {
               const approvalMap: Record<string, string> = {
-                'default': 'suggest',
-                'plan': 'suggest',
-                'acceptEdits': 'auto-edit',
+                'default': 'ask',
+                'plan': 'ask',
+                'acceptEdits': 'auto',
                 'bypassPermissions': 'full-auto'
               }
               const approvalMode = approvalMap[permissionMode] || 'suggest'
-              args = ['--approval-mode', approvalMode, prompt]
+              args = ['--ask-for-approval', approvalMode, prompt]
               break
             }
             case 'opencode': {

--- a/src/extension/KanbanPanel.ts
+++ b/src/extension/KanbanPanel.ts
@@ -913,13 +913,13 @@ export class KanbanPanel {
       }
       case 'codex': {
         const approvalMap: Record<string, string> = {
-          'default': 'suggest',
-          'plan': 'suggest',
-          'acceptEdits': 'auto-edit',
+          'default': 'ask',
+          'plan': 'ask',
+          'acceptEdits': 'auto',
           'bypassPermissions': 'full-auto'
         }
         const approvalMode = approvalMap[selectedPermissionMode] || 'suggest'
-        args = ['--approval-mode', approvalMode, prompt]
+        args = ['--ask-for-approval', approvalMode, prompt]
         break
       }
       case 'copilot': {


### PR DESCRIPTION
## Summary
Replace deprecated  flag with  in two files, updating the mode map values to match current Codex CLI 0.115.0+ options.

## Changes

| File | Old | New |
|------|-----|-----|
| KanbanPanel.ts |  |  |
| KanbanPanel.ts |  |  |
| FeatureHeaderProvider.ts | same pattern | same |

## Codex CLI migration
-  removed in Codex CLI 0.115.0
- New flags:  () and 
- Mode values:  -> ,  -> ,  -> 

Fixes #47